### PR TITLE
Fix encoding maps with 16+ entries

### DIFF
--- a/msgpack-tests.el
+++ b/msgpack-tests.el
@@ -234,7 +234,10 @@
 
 (ert-deftest msgpack-encode-alist ()
   (should (equal (msgpack-encode-alist ()) (unibyte-string #x80)))
-  (should (equal (msgpack-encode-alist '((1 . 2) (3 . 4))) (unibyte-string #b10000010 1 2 3 4))))
+  (should (equal (msgpack-encode-alist '((1 . 2) (3 . 4))) (unibyte-string #b10000010 1 2 3 4)))
+  (let ((alist (mapcar (lambda (i) (cons i i)) (number-sequence 1 16))))
+    (should (equal (substring (msgpack-encode-alist alist) 0 3)
+                   (unibyte-string #xde 0 16)))))
 
 (ert-deftest msgpack-encode-plist ()
   (should (equal (msgpack-encode-plist '(1 2 3 4)) (unibyte-string #b10000010 1 2 3 4)))

--- a/msgpack.el
+++ b/msgpack.el
@@ -556,9 +556,9 @@ in the result."
       ((<= n 15)
        (unibyte-string (logior #b10000000 n)))
       ((<= n #xffff)
-       (unibyte-string #xde (msgpack-unsigned-to-bytes n 2)))
+       (concat (unibyte-string #xde) (msgpack-unsigned-to-bytes n 2)))
       ((<= n (1- (expt 2 32)))
-       (unibyte-string #xdf (msgpack-unsigned-to-bytes n 4))))
+       (concat (unibyte-string #xdf) (msgpack-unsigned-to-bytes n 4))))
      (cl-loop for (k . v) in alist
               concat (concat
                       (msgpack-encode k)


### PR DESCRIPTION
Fix the map16/map32 encoding paths so maps with 16 or more entries can be encoded.

The previous code passed the length byte string as an argument to `unibyte-string`, which only stayed hidden while fixmap was used. This builds the prefix with `concat` and adds a regression test for the 16-entry boundary.

This is the first PR in a small series. Later PRs build on this one and should be rebased after it lands.

Assisted by pi/gpt-5.5