### PR TITLE
Add external conformance suite coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,28 @@ jobs:
       with:
         version: ${{ matrix.emacs_version }}
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Byte compile
       run: 'emacs -Q --batch --eval "(setq byte-compile-error-on-warn t)" -f batch-byte-compile msgpack.el'
     - name: Run tests
       run: 'emacs -Q --batch -L . -l msgpack-tests -f ert-run-tests-batch-and-exit'
+
+  conformance:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: purcell/setup-emacs@master
+      with:
+        version: 29.4
+
+    - uses: actions/checkout@v4
+    - name: Download conformance suite
+      run: |
+        curl -fsSL \
+          https://raw.githubusercontent.com/kawanet/msgpack-test-suite/e04f6edeaae589c768d6b70fcce80aa786b7800e/dist/msgpack-test-suite.json \
+          -o msgpack-test-suite.json
+    - name: Run conformance tests
+      run: |
+        emacs -Q --batch -L . \
+          --eval "(setq msgpack-test-suite-file \"$(pwd)/msgpack-test-suite.json\")" \
+          -l msgpack-tests \
+          --eval "(ert-run-tests-batch-and-exit \"^msgpack-external-conformance-suite$\")"

--- a/msgpack-tests.el
+++ b/msgpack-tests.el
@@ -63,8 +63,18 @@
                (msgpack-read-from-string (unibyte-string #xd3 #x80 #x00 #x00 #x00 #x00 #x00 #x00 #x00)))))
   ;; float
   (should (= 0.15625 (msgpack-read-from-string (unibyte-string #xca #x3e #x20 #x00 #x00))))
+  (should (= (/ 1.0 0.0) (/ 1.0 (msgpack-read-from-string (unibyte-string #xca 0 0 0 0)))))
+  (should (= (/ -1.0 0.0) (/ 1.0 (msgpack-read-from-string (unibyte-string #xca #x80 0 0 0)))))
+  (should (= (/ 1.0 0.0) (msgpack-read-from-string (unibyte-string #xca #x7f #x80 0 0))))
+  (should (= (/ -1.0 0.0) (msgpack-read-from-string (unibyte-string #xca #xff #x80 0 0))))
+  (should (isnan (msgpack-read-from-string (unibyte-string #xca #x7f #xc0 0 0))))
   ;; double
   (should (= 0.15625 (msgpack-read-from-string (unibyte-string #xcb #x3f #xc4 #x00 #x00 #x00 #x00 #x00 #x00))))
+  (should (= (/ 1.0 0.0) (/ 1.0 (msgpack-read-from-string (unibyte-string #xcb 0 0 0 0 0 0 0 0)))))
+  (should (= (/ -1.0 0.0) (/ 1.0 (msgpack-read-from-string (unibyte-string #xcb #x80 0 0 0 0 0 0 0)))))
+  (should (= (/ 1.0 0.0) (msgpack-read-from-string (unibyte-string #xcb #x7f #xf0 0 0 0 0 0 0))))
+  (should (= (/ -1.0 0.0) (msgpack-read-from-string (unibyte-string #xcb #xff #xf0 0 0 0 0 0 0))))
+  (should (isnan (msgpack-read-from-string (unibyte-string #xcb #x7f #xf8 0 0 0 0 0 0))))
   ;; string within [0, 31] bytes
   (should (equal "" (msgpack-read-from-string (unibyte-string #b10100000))))
   (should (equal "hello" (msgpack-read-from-string (unibyte-string #b10100101 ?h ?e ?l ?l ?o))))
@@ -162,7 +172,9 @@
 (ert-deftest msgpack-byte-to-signed ()
   (should (= (msgpack-byte-to-signed #x80) -128))
   (should (= (msgpack-byte-to-signed #xff) -1))
-  (should (= (msgpack-byte-to-signed #x7f) 127)))
+  (should (= (msgpack-byte-to-signed #x7f) 127))
+  (should (= (msgpack-bytes-to-signed (unibyte-string #xff #xff #xff #xff #xff #xff #xff #xff))
+             -1)))
 
 (ert-deftest msgpack-encode-integer ()
   ;; [0, 127]
@@ -380,6 +392,17 @@
                         #xc7 12 -1
                         (msgpack-unsigned-to-bytes nanoseconds 4)
                         (msgpack-unsigned-to-bytes seconds 8)))
+      (`(,high ,low ,micro ,pico)
+       (should (= seconds (+ (* high (expt 2 16)) low)))
+       (should (= nanoseconds (+ (* 1000 micro) pico))))))
+
+  (let ((seconds -1)
+        (nanoseconds 42000))
+    (pcase-exhaustive (msgpack-read-from-string
+                       (msgpack-concat
+                        #xc7 12 -1
+                        (msgpack-unsigned-to-bytes nanoseconds 4)
+                        (msgpack-signed-to-bytes seconds 8)))
       (`(,high ,low ,micro ,pico)
        (should (= seconds (+ (* high (expt 2 16)) low)))
        (should (= nanoseconds (+ (* 1000 micro) pico)))))))

--- a/msgpack-tests.el
+++ b/msgpack-tests.el
@@ -26,6 +26,10 @@
 (require 'ert)
 (require 'msgpack)
 (require 'map)
+(require 'json)
+
+(defvar msgpack-test-suite-file nil
+  "Path to kawanet/msgpack-test-suite JSON file, or nil to skip it.")
 
 (ert-deftest msgpack-read ()
   ;; nil, false, true
@@ -419,6 +423,91 @@
   (should (equal (msgpack-signed-to-bytes-fallback -1 8) (unibyte-string #xff #xff #xff #xff #xff #xff #xff #xff)))
   (should (equal (msgpack-signed-to-bytes-fallback -30 4) (unibyte-string #xff #xff #xff #xe2)))
   (should (equal (msgpack-signed-to-bytes-fallback -30 8) (unibyte-string #xff #xff #xff #xff #xff #xff #xff #xe2))))
+
+(defun msgpack-test--hex-to-bytes (hex)
+  "Convert dash-separated HEX bytes to a unibyte string."
+  (apply #'unibyte-string
+         (mapcar (lambda (part) (string-to-number part 16))
+                 (split-string hex "-" t))))
+
+(defun msgpack-test--json-value-to-expected (value)
+  "Convert JSON test suite VALUE to the expected decoded Lisp value."
+  (cond
+   ((eq value :json-false) :json-false)
+   ((eq value :json-null) :json-null)
+   ((vectorp value)
+    (vconcat (mapcar #'msgpack-test--json-value-to-expected value)))
+   ((listp value)
+    (mapcar (lambda (pair)
+              (cons (symbol-name (car pair))
+                    (msgpack-test--json-value-to-expected (cdr pair))))
+            value))
+   (t value)))
+
+(defun msgpack-test--suite-entry-expected (entry)
+  "Return expected decoded value for a conformance suite ENTRY."
+  (cond
+   ((assq 'nil entry) :json-null)
+   ((assq 'bool entry) (if (eq (cdr (assq 'bool entry)) :json-false)
+                           :json-false
+                         t))
+   ((assq 'binary entry)
+    (msgpack-bin-make
+     (msgpack-test--hex-to-bytes (cdr (assq 'binary entry)))))
+   ((assq 'bignum entry)
+    (string-to-number (cdr (assq 'bignum entry))))
+   ((assq 'number entry) (cdr (assq 'number entry)))
+   ((assq 'string entry) (cdr (assq 'string entry)))
+   ((assq 'array entry)
+    (vconcat (mapcar #'msgpack-test--json-value-to-expected
+                     (cdr (assq 'array entry)))))
+   ((assq 'map entry)
+    (msgpack-test--json-value-to-expected (cdr (assq 'map entry))))
+   ((assq 'timestamp entry)
+    (let* ((parts (cdr (assq 'timestamp entry)))
+           (seconds (aref parts 0))
+           (nanoseconds (aref parts 1)))
+      (msgpack-seconds-to-time seconds nanoseconds)))
+   ((assq 'ext entry)
+    (let ((ext (cdr (assq 'ext entry))))
+      (msgpack-ext-make (aref ext 0)
+                        (msgpack-test--hex-to-bytes (aref ext 1)))))
+   (t (error "Unsupported test suite entry: %S" entry))))
+
+(defun msgpack-test--equal-decoded-p (expected actual)
+  "Return non-nil if EXPECTED and ACTUAL decoded values are equivalent."
+  (cond
+   ((and (numberp expected) (numberp actual))
+    (= expected actual))
+   ((and (msgpack-bin-p expected) (msgpack-bin-p actual))
+    (equal (msgpack-bin-string expected) (msgpack-bin-string actual)))
+   ((and (msgpack-ext-p expected) (msgpack-ext-p actual))
+    (and (= (msgpack-ext-type expected) (msgpack-ext-type actual))
+         (equal (msgpack-ext-data expected) (msgpack-ext-data actual))))
+   (t (equal expected actual))))
+
+(ert-deftest msgpack-external-conformance-suite ()
+  (skip-unless (and msgpack-test-suite-file
+                    (file-exists-p msgpack-test-suite-file)))
+  (let* ((json-object-type 'alist)
+         (json-array-type 'vector)
+         (json-false :json-false)
+         (json-null :json-null)
+         (suite (json-read-file msgpack-test-suite-file)))
+    (dolist (group suite)
+      (cl-loop for entry across (cdr group)
+               for expected = (msgpack-test--suite-entry-expected entry)
+               do (cl-loop for hex across (cdr (assq 'msgpack entry))
+                           for bytes = (msgpack-test--hex-to-bytes hex)
+                           for actual = (msgpack-decode bytes
+                                                        :array-type 'vector
+                                                        :map-type 'alist
+                                                        :key-type 'string
+                                                        :bin-type 'msgpack-bin
+                                                        :null-value :json-null
+                                                        :false-value :json-false)
+                           do (should (msgpack-test--equal-decoded-p
+                                       expected actual)))))))
 
 (provide 'msgpack-tests)
 ;;; msgpack-tests.el ends here

--- a/msgpack.el
+++ b/msgpack.el
@@ -121,41 +121,59 @@ Must be either `string' for the historical raw unibyte string behavior or
            for n across (nreverse bytes)
            sum (* n (expt (expt 2 8) i))))
 
+(defun msgpack--bytes-negative-p (bytes)
+  "Return non-nil if BYTES encode a negative two's-complement integer."
+  (not (zerop (logand (aref bytes 0) #x80))))
+
+(defun msgpack--bytes-invert (bytes)
+  "Return BYTES with every bit inverted."
+  (apply #'unibyte-string
+         (cl-loop for byte across bytes collect (logxor byte #xff))))
+
 (defun msgpack-bytes-to-signed (bytes)
   "Convert BYTES to signed int."
-  (let ((nbits (* 8 (length bytes)))
-        (num (msgpack-bytes-to-unsigned bytes)))
-    (pcase (ash num (- (1- nbits)))     ; sign
-      (0 num)
-      (1 (- num (expt 2 nbits))))))
+  (if (msgpack--bytes-negative-p bytes)
+      (- (1+ (msgpack-bytes-to-unsigned (msgpack--bytes-invert bytes))))
+    (msgpack-bytes-to-unsigned bytes)))
 
 (defun msgpack-byte-to-signed (byte)
   "Convert BYTE to signed int."
-  (msgpack-bytes-to-signed (unibyte-string byte)))
+  (if (< byte 128) byte (- byte 256)))
 
 (defun msgpack-bytes-to-bits (bytes)
   "Convert BYTES to bits."
   (cl-mapcan #'msgpack-byte-to-bits bytes))
 
+(defun msgpack--bytes-to-ieee-float (bytes exponent-bits fraction-bits bias)
+  "Convert IEEE 754 BYTES to a floating-point number.
+EXPONENT-BITS, FRACTION-BITS, and BIAS describe the float format."
+  (let* ((bits (msgpack-bytes-to-bits bytes))
+         (sign (if (zerop (car bits)) 1.0 -1.0))
+         (exponent-end (1+ exponent-bits))
+         (exponent (msgpack-bits-to-unsigned (cl-subseq bits 1 exponent-end)))
+         (max-exponent (1- (expt 2 exponent-bits)))
+         (fraction (msgpack-bits-to-unsigned (cl-subseq bits exponent-end))))
+    (cond
+     ((= exponent max-exponent)
+      (if (zerop fraction)
+          (* sign (/ 1.0 0.0))
+        (/ 0.0 0.0)))
+     ((zerop exponent)
+      (if (zerop fraction)
+          (* sign 0.0)
+        (* sign fraction (expt 2.0 (- 1 bias fraction-bits)))))
+     (t
+      (* sign
+         (+ 1.0 (/ (float fraction) (expt 2.0 fraction-bits)))
+         (expt 2.0 (- exponent bias)))))))
+
 (defun msgpack-bytes-to-float (bytes)
   "Convert BYTES to IEEE 754 float."
-  (let* ((bits (msgpack-bytes-to-bits bytes))
-         (sign (car bits))
-         (e (msgpack-bits-to-unsigned (cl-subseq bits 1 9)))
-         (fraction (1+ (cl-loop for b in (cl-subseq bits 9)
-                                for i from 1 to 23
-                                sum (* b (expt 2 (- i)))))))
-    (* (expt -1 sign) (expt 2 (- e 127)) fraction)))
+  (msgpack--bytes-to-ieee-float bytes 8 23 127))
 
 (defun msgpack-bytes-to-double (bytes)
   "Convert BYTES to IEEE 754 double."
-  (let* ((bits (msgpack-bytes-to-bits bytes))
-         (sign (car bits))
-         (e (msgpack-bits-to-unsigned (cl-subseq bits 1 12)))
-         (fraction (1+ (cl-loop for b in (cl-subseq bits 12)
-                                for i from 1 to 52
-                                sum (* b (expt 2 (- i)))))))
-    (* (expt -1 sign) (expt 2 (- e 1023)) fraction)))
+  (msgpack--bytes-to-ieee-float bytes 11 52 1023))
 
 (defun msgpack-concat (&rest args)
   "Concatenate all the arguments ARGS and make the result a unibyte string."
@@ -255,7 +273,7 @@ using the formula: HIGH * 2**16 + LOW + MICRO * 10**-6 + PICO * 10**-12."
                       (seconds (msgpack-bits-to-unsigned (cl-subseq bits 30))))
                  (msgpack-seconds-to-time seconds nanoseconds)))
       ('(-1 12) (let ((nanoseconds (msgpack-bytes-to-unsigned (substring data 0 4)))
-                      (seconds (msgpack-bytes-to-unsigned (substring data 4))))
+                      (seconds (msgpack-bytes-to-signed (substring data 4))))
                   (msgpack-seconds-to-time seconds nanoseconds)))
       (_ (msgpack-ext-make type data)))))
 


### PR DESCRIPTION
This PR does two things:

1. Fix decoder edge cases exposed by the conformance fixtures:
   - IEEE 754 float32/float64 zero, infinity, NaN, and subnormal values
   - timestamp96 seconds decoded as signed 64-bit values
   - signed byte decoding without relying on bignums for negative int64 values near zero

2. Add optional external conformance coverage:
   - an ERT test that reads the kawanet msgpack-test-suite JSON when `msgpack-test-suite-file` is set
   - a CI job that downloads a pinned copy of that suite and runs only the external conformance test

The normal local test run still skips the external suite unless `msgpack-test-suite-file` is set.

Assisted by pi/gpt-5.5
